### PR TITLE
V0.3.0

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -77,3 +77,13 @@
         - Added new function 'export_makefile' to export the target and variable dictionaries into a proper Makefile structure
             + To be tested with print statement first
 
+#### 1335H
+- Updates
+    - Updated unit test file 'unittest.py' in 'tests/'
+        + Modified to match test requirements
+    - Updated source file 'mkparse.py' in 'src/mkparse'
+        - Fixed function 'export_Makefile'
+            + Able to export to a Makefile 
+        - TODO
+            + To implement reading of comments outside of variables and targets
+

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 + [2024-03-23](#2024-03-23)
++ [2024-03-24](#2024-03-24)
 
 ## Entry Logs
 ### 2024-03-23
@@ -32,4 +33,9 @@
     - Updated source file 'main.py' in 'src/'
         + Fixed formatting
 
+### 2024-03-24
+#### 2204H
+- Updates
+    - Updated source file 'mkparser.py' in 'src/mkparser'
+        + Added Makefile parser implementation (to be tested)
 

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -87,3 +87,25 @@
         - TODO
             + To implement reading of comments outside of variables and targets
 
+#### 1430H
++ Version: v0.3.0
+
+- Version Changes
+    + Added working Makefile-to-Python import/parser support
+    + Added working Python-to-Makefile export function
+
+- TODO Ideas
+    + Add comment import such that all comments on the global scope (not tied to any targets) will be retrievable
+
+- Updates
+    - Updated source file 'mkparse.py' in 'src/mkparse'
+        - Function 'makefile_parse()'
+            + Added logical check for comments ('#') and to map that line number to the comment for future use
+            + Added 'comments' to the return list
+            + Added 'comments' to the documentation multiline docstring
+    - Updated document 'USAGE.md'
+        + Fixed usage example of 'parse_makefile()': Swapped the argument signatures
+        + Updated return list of 'parse_makefile()'
+        + Added documentation for function 'export_makefile()'
+        + Updated general usage examples
+

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 + [2024-03-23](#2024-03-23)
 + [2024-03-24](#2024-03-24)
++ [2024-03-25](#2024-03-25)
 
 ## Entry Logs
 ### 2024-03-23
@@ -64,4 +65,15 @@
         - Fixing implementation of Makefile Parser in 'parse_makefiles();'
             - Target is still bugged
                 + Having issues detecting if dependencies is found
+
+### 2024-03-25
+#### 1202H
+- Updates
+    - Updated unit test file 'unittest.py' in 'tests/'
+        + Modified to match test requirements
+    - Updated source file 'mkparse.py' in 'src/mkparse'
+        + Fixed Makefile to Python parser logic - To be tested
+        + Wrote documentation comment headers in function
+        - Added new function 'export_makefile' to export the target and variable dictionaries into a proper Makefile structure
+            + To be tested with print statement first
 

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -39,3 +39,8 @@
     - Updated source file 'mkparser.py' in 'src/mkparser'
         + Added Makefile parser implementation (to be tested)
 
+#### 2208H
+- Updates
+    - Updated document 'README.md'
+        + Fixed pip install URL
+

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -44,3 +44,24 @@
     - Updated document 'README.md'
         + Fixed pip install URL
 
+#### 2344H
+- New
+    - Added new directory 'tests/' for writing unit tests and other tests
+        + Added new unit test source 'unittest.py' for holding the main unit tests
+        - Added new directory 'resources/' for holding test resource files
+            - Added new directory 'Makefiles' for holding Makefile resources
+                + Added new test Makefile 'test.Makefile'
+
+- Updates
+    - Updated document 'README.md'
+        + Added new instruction for installing package in editable local development mode
+    - Updated document 'requirements.txt'
+        + Added the repository's github link as an installable pip package
+    - Updated source file 'main.py' in 'src/'
+    - Updated source file 'mkparse.py' in 'src/mkparse'
+        + Swapped parameter/argument signatures
+        + The variable dictionary now returns the operator (string), and the values (list) mapped to the variable name
+        - Fixing implementation of Makefile Parser in 'parse_makefiles();'
+            - Target is still bugged
+                + Having issues detecting if dependencies is found
+

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Makefile Parser in Python
     pip install .
     ```
 
+- Install locally in editable development mode
+    ```bash
+    pip install -e .
+    ```
+
 - Install Python package using GitHub repository via setuptools
     ```bash
     pip install git+https://github.com/Thanatisia/makefile-parser-python

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Makefile Parser in Python
 
 - Install Python package using GitHub repository via setuptools
     ```bash
-    pip install https://github.com/Thanatisia/mkparser
+    pip install git+https://github.com/Thanatisia/makefile-parser-python
     ```
 
 ## Wiki

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Makefile Parser in Python
 
 ### Project
 + Package Name: mkparser-python
-+ Current Version: v0.2.0
++ Current Version: v0.3.0
 
 ## Setup
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -37,6 +37,78 @@ Information regarding the various ways to use this Makefile parser
             - Values
                 + targets   : Makefile rules/targets + dependencies
                 + variables : Makefile variables/build arguments
+                + comments  : Makefile comments from the global scope (not tied to any targets); Currently unused
+    - `.export_Makefile(targets:dict, variables:dict, makefile_name="Makefile", makefile_path=".")` : Export the targets and variables list into an output Makefile
+        - Parameter/Argument Signatures
+            - targets: Pass the new targets list you wish to export
+                + Type: Dictionary
+                - Format
+                    ```python
+                    {
+                        "target-name" : {
+                            "dependencies" : [your, dependencies, here],
+                            "statements" : [your, statements, here]
+                        }
+                    }
+                    ```
+                - Key-Value Explanation
+                    - target-name : Each entry of 'target-name' contains a Makefile build target/instruction/rule 
+                        - Key-Value Mappings
+                            - dependencies : Specify a list of all dependencies 
+                                - Notes: 
+                                    - Dependencies are the pre-requisite rules to execute before executing the mapped target
+                                        - i.e.
+                                            ```make
+                                            [target-name]: [dependencies ...]
+                                            ```
+                            - statements : Specify a list of all rows of statements to write under the target
+                                - Examples
+                                    ```make
+                                    [target-name]:
+                                        # Statements...
+                                    ```
+            - variables : Pass the new variables list you wish to export
+                + Type: Dictionary 
+                - Format
+                    ```python
+                    {
+                        "variable-name" : {
+                            "operator" : "operator (i.e. =|?=|:=)",
+                            "value" : [your, values, here]
+                        }
+                    }
+                    ```
+                - Key-Value Explanation
+                    - variable-name : Each entry of 'variable-name' contains a Makefile variable/ingredient
+                        - Key-Value Mappings
+                            - operator : Specify the operator to map the variable to its value string/array/list
+                                + Type: String
+                                - Operator Keyword Types
+                                    + '='
+                                    + '?='
+                                    + ':='
+                            - value : Specify the value string/array/list (as a list) that you want to map to the variable
+                                + Type: List
+            - makefile_name : Specify the name of the output Makefile to export to
+                + Type: String
+                + Default Value: "Makefile"
+            - makefile_path : Specify the path containing the output Makefile to export to
+                + Type: String
+                + Default Value: "." (Current Working Directory)
+
+        - Output
+            + Type: void/null/None
+            - Write the provided Makefile specifications to an output Makefile of the following attributes
+                + File Name: [makefile_path]/[makefile_name]
+                + File Type: Makefile
+                - Format:
+                    ```
+                    [variable-name] = variable values
+
+                    [target-name] : your dependencies here
+                        # Instructions/statements
+                    ```
+        """
 
 ### Data Classes/Types
 
@@ -63,16 +135,38 @@ Information regarding the various ways to use this Makefile parser
     makefile_name = "Makefile"
     ```
 
+- (Optional) Obtain makefile arguments as a CLI argument
+    ```python
+    # Initialize Variables
+    exec = sys.argv[0]
+    argv = sys.argv[1:]
+    argc = len(argv)
+    makefile_path = "."
+    makefile_name = "Makefile"
+
+    # Get Arguments
+    if argc >= 2:
+        makefile_path = argv[0]
+        makefile_name = argv[1]
+    ```
+
 - Initialize Module Classes
     - MakefileParser : The primary makefile file parser
         ```python
-        makefile_parser = MakefileParser(makefile_path, makefile_name) # Initialize Makefile Parser
+        makefile_parser = MakefileParser(makefile_name, makefile_path) # Initialize Makefile Parser
         ```
 
 - Import Makefile file contents into python dictionary (key-value mappings; i.e. HashMap/Associative Array)
+    - Notes
+        - If you do not require any of the return objects
+            - You can just replace the output object with '_'
+                - i.e.
+                    ```python
+                    targets, variables, _ = makefile_parser.parse_makefile(makefile_name, makefile_path)
+                    ```
     ```python
     # Import Makefile contents into application runtime
-    targets, variables = makefile_parser.parse_makefile(makefile_path, makefile_name)
+    targets, variables, comments = makefile_parser.parse_makefile(makefile_name, makefile_path)
     ```
 
 - Process imported Makefile contents
@@ -86,8 +180,11 @@ Information regarding the various ways to use this Makefile parser
     ```
 
 - Output processed data 
-    ```python
-    ```
+    - Export dictionaries to Makefile
+        ```python
+        # Export Makefile dictionaries to Makefile
+        makefile_parser.export_Makefile(targets, variables, makefile_name, makefile_path)       
+        ```
 
 ## Resources
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Python package requirements/dependencies
 
 pyright
+git+https://github.com/Thanatisia/makefile-parser-python
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mkparse',
-    version='0.2.0',
+    version='0.3.0',
     description="A simple Makefile Parser written in Python that is designed to simplify the process of importing Makefile contents into python as dictionary (key-value mappings (i.e. hashmap/associative arrays)) objects",
     author='Thanatisia',
     author_email='55834101+Thanatisia@users.noreply.github.com',

--- a/src/main.py
+++ b/src/main.py
@@ -9,10 +9,10 @@ def main():
     # Initialize Variables
     makefile_path = "."
     makefile_name = "Makefile"
-    makefile_parser = MakefileParser(makefile_path, makefile_name) # Initialize Makefile Parser
+    makefile_parser = MakefileParser(makefile_name, makefile_path) # Initialize Makefile Parser
 
     # Import Makefile contents into application runtime
-    targets, variables = makefile_parser.parse_makefile(makefile_path, makefile_name)
+    targets, variables = makefile_parser.parse_makefile(makefile_name, makefile_path)
 
     # Process imported Makefile contents
 

--- a/src/mkparse/mkparse.py
+++ b/src/mkparse/mkparse.py
@@ -27,11 +27,54 @@ class MakefileParser():
         :: Makefile target/rules Format:
              [target-name]: [dependencies]
                  # statements...
+
+        :: Output
+        - targets: Pass the new targets list you wish to export
+            + Type: Dictionary
+            - Format
+                {
+                    "target-name" : {
+                        "dependencies" : [your, dependencies, here],
+                        "statements" : [your, statements, here]
+                    }
+                }
+            - Key-Value Explanation
+                - target-name : Each entry of 'target-name' contains a Makefile build target/instruction/rule 
+                    - Key-Value Mappings
+                        - dependencies : Specify a list of all dependencies 
+                            - Notes: 
+                                - Dependencies are the pre-requisite rules to execute before executing the mapped target
+                                    - i.e.
+                                        [target-name]: [dependencies ...]
+                        - statements : Specify a list of all rows of statements to write under the target
+        - variables : Pass the new variables list you wish to export
+            + Type: Dictionary 
+            - Format
+                {
+                    "variable-name" : {
+                        "operator" : "operator (i.e. =|?=|:=)",
+                        "value" : [your, values, here]
+                    }
+                }
+            - Key-Value Explanation
+                - variable-name : Each entry of 'variable-name' contains a Makefile variable/ingredient
+                    - Key-Value Mappings
+                        - operator : Specify the operator to map the variable to its value string/array/list
+                            + Type: String
+                            - Operator Keyword Types
+                                + '='
+                                + '?='
+                                + ':='
+                        - value : Specify the value string/array/list (as a list) that you want to map to the variable
+                            + Type: List
         """
         # Initialize Variables
         targets = {}
         variables = {}
-        current_target = None
+        curr_target = None
+        curr_target_name = ""
+        line_number = 0
+        comments = {} # Store comments here; map line number to the comment
 
         # Process and perform data validation + sanitization
         
@@ -48,54 +91,97 @@ class MakefileParser():
             with open(os.path.join(makefile_path, makefile_name), 'r') as makefile:
                 for line in makefile:
                     # Remove comments
-                    line = line.split('#', 1)[0]
-                    line = line.strip()
+                    # line = line.split('#', 1)[0]
+                    line = line.rstrip()
 
                     # Check if line is empty after removing comments
                     if not line:
+                        # Line is empty, continue
                         continue
 
-                    # Check if line defines a new target
-                    if line.endswith(':'):
-                        # Remove newline
-                        current_target = line[:-1].strip()
+                    # Check if line contains a '=' (defines a variable)
+                    if '=' in line:
+                        # Split the '=' to a LHS and RHS
+                        parts = line.split(' ')
 
-                        # Initialize a new entry for the current target
-                        targets[current_target] = {"dependencies" : [], "statements" : []}
-                    elif current_target:
-                        # Check if line defines a new target with/without dependencies (by checking if the last element is ':'
-                        if line[:-1][0] == ':':
-                            # Split dependencies
-                            dependencies = line.split()
-                            # Append dependencies to the current target
-                            targets[current_target]['dependencies'].extend(dependencies)
+                        # Validate/Verify parts list is more than or equals to 2 : Name, Operator and Value, value might be empty
+                        if len(parts) >= 2:
+                            # Strip the newline off the first element which is the variable name
+                            variable_name = parts[0].strip()
+
+                            # Obtain Operator
+                            operator = parts[1]
+
+                            # Set empty value
+                            variable_value = []
+
+                            # Check if variable value is provided
+                            if len(parts) >= 3:
+                                # Obtain variable value
+                                variable_value = parts[2:]
+
+                            # Map the variable value to the variable name in the entry mapping
+                            variables[variable_name] = {'operator': operator, 'value': variable_value}
+
+                    # Check if line contains ':' (defines a target)
+                    elif ':' in line:
+                        # Check if line ends with ':' (does not have any dependencies)
+                        if line.endswith(':'):
+                            # Ends with ':' == there are no dependencies, also is definitely a target
+                            curr_target_name = line.split(':')[0].strip()
+
+                            # Initialize a new entry for the current target
+                            targets[curr_target_name] = {"dependencies" : [], "statements" : []}
+                        else:
+                            # Does not end with ':' == there are dependencies
+
+                            # Check if line is really a target and not a statement
+                            if not ('\t' in line):
+                                # This is a target with dependencies
+
+                                # Split line by ':'
+                                curr_target = line.split(':')
+                                curr_target_name = curr_target[0].strip()
+                                curr_target_dependencies = curr_target[1].strip()
+
+                                # Initialize a new entry for the current target
+                                targets[curr_target_name] = {"dependencies" : [], "statements" : []}
+
+                                # Null-value validation
+                                if curr_target_dependencies == "":
+                                    curr_target_dependencies = None
+
+                                # Remove newline
+                                # current_target = line[:-1].rstrip()
+
+                                # Check if dependencies are required
+                                if not(curr_target_dependencies == None):
+                                    # Are required
+                                    # Append dependencies to the current target
+                                    targets[curr_target_name]['dependencies'].append(curr_target_dependencies)
+
+                    # Not target = statements, append statements to the target
+
+                    # Check for empty name
+                    if not (curr_target_name == '') :
+                        # There's tab, a target does not have indentations (means that this is a statement)
 
                         # Store each row of the target's recipe in its own list
-                        targets[current_target]['statements'].append(line.strip())
-                    else:
-                        # Check if line defines a variable
-                        if '=' in line:
-                            # Split the '=' to a LHS and RHS
-                            parts = line.split(' ')
+                        targets[curr_target_name]['statements'].append(line.rstrip())
 
-                            # Validate/Verify parts list is more than or equals to 2 : Name, Operator and Value, value might be empty
-                            if len(parts) >= 2:
-                                # Strip the newline off the first element which is the variable name
-                                variable_name = parts[0].strip()
+                    # Increment Line Number
+                    line_number += 1
 
-                                # Obtain Operator
-                                operator = parts[1]
+                for curr_target_name,curr_target_values in targets.items():
+                    # Get current target's dependencies
+                    curr_target_dependencies = curr_target_values["dependencies"]
 
-                                # Set empty value
-                                variable_value = []
+                    # Get current target's statements
+                    curr_target_statements = curr_target_values["statements"]
 
-                                # Check if variable value is provided
-                                if len(parts) >= 3:
-                                    # Obtain variable value
-                                    variable_value = parts[2:]
-
-                                # Map the variable value to the variable name in the entry mapping
-                                variables[variable_name] = {'operator': operator, 'value': variable_value}
+                    # Remove the first line from the list
+                    targets[curr_target_name]['statements'] = curr_target_statements[1:]
+                    print("Sanity Check: {}".format(targets[curr_target_name]['statements']))
 
                 # Close file after usage
                 makefile.close()
@@ -103,4 +189,96 @@ class MakefileParser():
             print("Makefile not found.")
 
         return [targets, variables]
-    
+
+    def export_Makefile(self, targets:dict, variables:dict, makefile_name="Makefile", makefile_path="."):
+        """
+        Export the targets and variables list into an output Makefile
+
+        :: Params
+        - targets: Pass the new targets list you wish to export
+            + Type: Dictionary
+            - Format
+                {
+                    "target-name" : {
+                        "dependencies" : [your, dependencies, here],
+                        "statements" : [your, statements, here]
+                    }
+                }
+            - Key-Value Explanation
+                - target-name : Each entry of 'target-name' contains a Makefile build target/instruction/rule 
+                    - Key-Value Mappings
+                        - dependencies : Specify a list of all dependencies 
+                            - Notes: 
+                                - Dependencies are the pre-requisite rules to execute before executing the mapped target
+                                    - i.e.
+                                        [target-name]: [dependencies ...]
+                        - statements : Specify a list of all rows of statements to write under the target
+        - variables : Pass the new variables list you wish to export
+            + Type: Dictionary 
+            - Format
+                {
+                    "variable-name" : {
+                        "operator" : "operator (i.e. =|?=|:=)",
+                        "value" : [your, values, here]
+                    }
+                }
+            - Key-Value Explanation
+                - variable-name : Each entry of 'variable-name' contains a Makefile variable/ingredient
+                    - Key-Value Mappings
+                        - operator : Specify the operator to map the variable to its value string/array/list
+                            + Type: String
+                            - Operator Keyword Types
+                                + '='
+                                + '?='
+                                + ':='
+                        - value : Specify the value string/array/list (as a list) that you want to map to the variable
+                            + Type: List
+        - makefile_name : Specify the name of the output Makefile to export to
+            + Type: String
+            + Default Value: "Makefile"
+        - makefile_path : Specify the path containing the output Makefile to export to
+            + Type: String
+            + Default Value: "."
+
+        :: Output
+        - File Name: [makefile_path]/[makefile_name]
+        - File Type: Makefile
+        - Format:
+            ```
+            [variable-name] = variable values
+            [target-name] : your dependencies here
+                # Instructions/statements
+            ```
+        """
+        # Initialize Variables
+        makefile_fullpath = os.path.join(makefile_path, makefile_name)
+
+        # Check if file exists
+        if os.path.isfile(makefile_fullpath):
+            # Open file
+            with open(makefile_fullpath, "a+") as export_Makefile:
+                # Loop through all variables
+                for variable_name, variable_mappings in variables.items():
+                    # Obtain variable map operator
+                    variable_operator = variable_mappings["operator"]
+
+                    # Obtain variable values
+                    variable_values = variable_mappings["value"]
+
+                    # Write to Makefile
+                    print("{} {} {}".format(variable_name, variable_operator, variable_values))
+
+                # Loop through all targets
+                for target_name, target_mappings in targets.items():
+                    # Obtain target dependencies
+                    target_dependencies = target_mappings["dependencies"]
+
+                    # Obtain target statements
+                    target_statements = target_mappings["statements"]
+
+                    # Write to Makefile
+                    print("{}: {}\n{}".format(target_name, target_dependencies, target_statements))
+
+                # Close file after usage
+                export_Makefile.close()
+

--- a/src/mkparse/mkparse.py
+++ b/src/mkparse/mkparse.py
@@ -67,6 +67,16 @@ class MakefileParser():
                                 + ':='
                         - value : Specify the value string/array/list (as a list) that you want to map to the variable
                             + Type: List
+        - comments : Pass the updated global comments list you wish to export (NOTE: Currently unused; for future development plans)
+            + Type: Dictionary 
+            - Format
+                {
+                    "line-number" : comment-from-that-line
+                }
+            - Key-Value Explanation
+                - variable-name : Each entry of 'variable-name' contains a Makefile variable/ingredient
+                    - Key-Value Mappings
+                        - line-number: The line number; this is mapped to the comment stored at that line
         """
         # Initialize Variables
         targets = {}
@@ -99,8 +109,13 @@ class MakefileParser():
                         # Line is empty, continue
                         continue
 
+                    # Check if line contains a '#' (a comment)
+                    if line[0] == '#':
+                        # Store all comments
+                        comments[line_number] = line
+
                     # Check if line contains a '=' (defines a variable)
-                    if '=' in line:
+                    elif '=' in line:
                         # Split the '=' to a LHS and RHS
                         parts = line.split(' ')
 
@@ -188,7 +203,7 @@ class MakefileParser():
         except FileNotFoundError:
             print("Makefile not found.")
 
-        return [targets, variables]
+        return [targets, variables, comments]
 
     def export_Makefile(self, targets:dict, variables:dict, makefile_name="Makefile", makefile_path="."):
         """
@@ -270,8 +285,6 @@ class MakefileParser():
                     export_Makefile.write(out_str)
 
                 export_Makefile.write("\n")
-
-                print("")
 
                 # Loop through all targets
                 for target_name, target_mappings in targets.items():

--- a/src/mkparse/mkparse.py
+++ b/src/mkparse/mkparse.py
@@ -254,7 +254,7 @@ class MakefileParser():
         makefile_fullpath = os.path.join(makefile_path, makefile_name)
 
         # Check if file exists
-        if os.path.isfile(makefile_fullpath):
+        if not (os.path.isfile(makefile_fullpath)):
             # Open file
             with open(makefile_fullpath, "a+") as export_Makefile:
                 # Loop through all variables
@@ -263,22 +263,30 @@ class MakefileParser():
                     variable_operator = variable_mappings["operator"]
 
                     # Obtain variable values
-                    variable_values = variable_mappings["value"]
+                    variable_values = ' '.join(variable_mappings["value"])
 
                     # Write to Makefile
-                    print("{} {} {}".format(variable_name, variable_operator, variable_values))
+                    out_str = "{} {} {}\n".format(variable_name, variable_operator, variable_values)
+                    export_Makefile.write(out_str)
+
+                export_Makefile.write("\n")
+
+                print("")
 
                 # Loop through all targets
                 for target_name, target_mappings in targets.items():
                     # Obtain target dependencies
-                    target_dependencies = target_mappings["dependencies"]
+                    target_dependencies = ' '.join(target_mappings["dependencies"])
 
                     # Obtain target statements
-                    target_statements = target_mappings["statements"]
+                    target_statements = '\n'.join(target_mappings["statements"])
 
                     # Write to Makefile
-                    print("{}: {}\n{}".format(target_name, target_dependencies, target_statements))
+                    out_str = "{}: {}\n{}\n".format(target_name, target_dependencies, target_statements)
+                    export_Makefile.write(out_str + "\n")
 
                 # Close file after usage
                 export_Makefile.close()
+        else:
+            print("Makefile {} already exists".format(makefile_fullpath))
 

--- a/src/mkparse/mkparse.py
+++ b/src/mkparse/mkparse.py
@@ -18,13 +18,23 @@ class MakefileParser():
     def parse_makefile(self, makefile_name="Makefile", makefile_path=".") -> list:
         """
         Parse Makefile into Python dictionary (Key-Value/HashMap) object
+
+        :: Syntaxes
+        :: =======
+        :: Makefile variables Format:
+            [variable-name] = [values ...]
+     
+        :: Makefile target/rules Format:
+             [target-name]: [dependencies]
+                 # statements...
         """
         # Initialize Variables
         targets = {}
         variables = {}
+        current_target = None
 
         # Process and perform data validation + sanitization
-
+        
         ## Use the default Makefile file name if not provided
         if makefile_name == "":
             makefile_name = self.makefile_name
@@ -33,6 +43,38 @@ class MakefileParser():
         if makefile_path == "":
             makefile_path = self.makefile_path
 
-        return [targets, variables]
+        # Try to open the Makefile
+        try:
+            with open(os.path.join(makefile_path, makefile_name), 'r') as makefile:
+                for line in makefile:
+                    # Remove comments
+                    line = line.split('#', 1)[0]
+                    line = line.strip()
 
+                    # Check if line is empty after removing comments
+                    if not line:
+                        continue
 
+                    # Check if line defines a new target
+                    if line.endswith(':'):
+                        current_target = line[:-1].strip()
+                        targets[current_target] = []
+                    elif current_target:
+                        # Append dependencies to the current target
+                        dependencies = line.split()
+                        targets[current_target].extend(dependencies)
+                    else:
+                        # Check if line defines a variable
+                        if '=' in line:
+                            parts = line.split('=')
+                            variable_name = parts[0].strip()
+                            variable_value = '='.join(parts[1:]).strip()
+                            variables[variable_name] = variable_value
+
+                # Close file after usage
+                makefile.close()
+        except FileNotFoundError:
+            print("Makefile not found.")
+
+        return targets, variables
+    

--- a/src/mkparse/mkparse.py
+++ b/src/mkparse/mkparse.py
@@ -57,24 +57,50 @@ class MakefileParser():
 
                     # Check if line defines a new target
                     if line.endswith(':'):
+                        # Remove newline
                         current_target = line[:-1].strip()
-                        targets[current_target] = []
+
+                        # Initialize a new entry for the current target
+                        targets[current_target] = {"dependencies" : [], "statements" : []}
                     elif current_target:
-                        # Append dependencies to the current target
-                        dependencies = line.split()
-                        targets[current_target].extend(dependencies)
+                        # Check if line defines a new target with/without dependencies (by checking if the last element is ':'
+                        if line[:-1][0] == ':':
+                            # Split dependencies
+                            dependencies = line.split()
+                            # Append dependencies to the current target
+                            targets[current_target]['dependencies'].extend(dependencies)
+
+                        # Store each row of the target's recipe in its own list
+                        targets[current_target]['statements'].append(line.strip())
                     else:
                         # Check if line defines a variable
                         if '=' in line:
-                            parts = line.split('=')
-                            variable_name = parts[0].strip()
-                            variable_value = '='.join(parts[1:]).strip()
-                            variables[variable_name] = variable_value
+                            # Split the '=' to a LHS and RHS
+                            parts = line.split(' ')
+
+                            # Validate/Verify parts list is more than or equals to 2 : Name, Operator and Value, value might be empty
+                            if len(parts) >= 2:
+                                # Strip the newline off the first element which is the variable name
+                                variable_name = parts[0].strip()
+
+                                # Obtain Operator
+                                operator = parts[1]
+
+                                # Set empty value
+                                variable_value = []
+
+                                # Check if variable value is provided
+                                if len(parts) >= 3:
+                                    # Obtain variable value
+                                    variable_value = parts[2:]
+
+                                # Map the variable value to the variable name in the entry mapping
+                                variables[variable_name] = {'operator': operator, 'value': variable_value}
 
                 # Close file after usage
                 makefile.close()
         except FileNotFoundError:
             print("Makefile not found.")
 
-        return targets, variables
+        return [targets, variables]
     

--- a/tests/resources/Makefiles/test.Makefile
+++ b/tests/resources/Makefiles/test.Makefile
@@ -1,0 +1,22 @@
+# Test Makefile
+
+## Variables/Ingredients
+
+SHELL := /bin/bash
+.PHONY := help
+.DEFAULT_RULES := help setup build
+
+## Recipe/Targets
+help:
+	## Display help message
+	@echo -e "[+] help : Display Help message"
+	@echo -e "[+] setup : Perform setup"
+	@echo -e "[+] build : Build from Source"
+
+setup:
+	## Perform setup 
+
+build: setup
+	## Build from source
+	@make -j3
+

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -41,6 +41,8 @@ def main():
     print("Targets")
     print("=======")
     for k,v in targets.items():
+        print("{} = {}".format(k,v))
+        """
         print("{} = ".format(k))
         for curr_target_key, curr_target_value in v.items():
             print("RAW: {} = {}".format(curr_target_key, curr_target_value))
@@ -48,12 +50,14 @@ def main():
             # Perform type checks
             if type(curr_target_value) == list:
                 # List type, print
+                print("\t\t{}".format(curr_target_value))
                 for i in range(len(curr_target_value)):
                     # Get current value
                     curr_val = curr_target_value[i]
                     print("\t\t{}".format(curr_val))
             else:
                 print("\t\t{}".format(curr_target_value))
+        """
 
     print("")
 

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -10,14 +10,14 @@ def test_Makefile(makefile_name = "Makefile", makefile_path = ".") -> list:
     makefile_parser = MakefileParser(makefile_name, makefile_path) # Initialize Makefile Parser
 
     # Import Makefile contents into application runtime
-    targets, variables = makefile_parser.parse_makefile(makefile_name, makefile_path)
+    targets, variables, comments = makefile_parser.parse_makefile(makefile_name, makefile_path)
 
     # Process imported Makefile contents
 
     # Use processed data
 
     # Output processed data
-    return [targets, variables]
+    return [targets, variables, comments]
 
 def test_export_Makefile(targets, variables, makefile_name="Makefile", makefile_path=".") -> None:
     # Initialize Variables
@@ -49,7 +49,7 @@ def main():
         makefile_name = argv[1]
 
     # Test Makefile import
-    targets, variables = test_Makefile(makefile_name, makefile_path)
+    targets, variables, comments = test_Makefile(makefile_name, makefile_path)
     print("=======")
     print("Targets")
     print("=======")

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -1,0 +1,68 @@
+"""
+Main Runner/Launcher
+"""
+import os
+import sys
+from mkparse.mkparse import MakefileParser
+
+def test_Makefile(makefile_name = "Makefile", makefile_path = ".") -> list:
+    # Initialize Variables
+    makefile_parser = MakefileParser(makefile_name, makefile_path) # Initialize Makefile Parser
+
+    # Import Makefile contents into application runtime
+    targets, variables = makefile_parser.parse_makefile(makefile_name, makefile_path)
+
+    # Process imported Makefile contents
+
+    # Use processed data
+
+    # Output processed data
+    return [targets, variables]
+
+def main():
+    """
+    Unit Test launcher
+    """
+    # Initialize Variables
+    exec = sys.argv[0]
+    argv = sys.argv[1:]
+    argc = len(argv)
+    makefile_path = "."
+    makefile_name = "Makefile"
+
+    # Get Arguments
+    if argc >= 2:
+        makefile_path = argv[0]
+        makefile_name = argv[1]
+
+    # Test Makefile import
+    targets, variables = test_Makefile(makefile_name, makefile_path)
+    print("=======")
+    print("Targets")
+    print("=======")
+    for k,v in targets.items():
+        print("{} = ".format(k))
+        for curr_target_key, curr_target_value in v.items():
+            print("RAW: {} = {}".format(curr_target_key, curr_target_value))
+            print("[{}]".format(curr_target_key))
+            # Perform type checks
+            if type(curr_target_value) == list:
+                # List type, print
+                for i in range(len(curr_target_value)):
+                    # Get current value
+                    curr_val = curr_target_value[i]
+                    print("\t\t{}".format(curr_val))
+            else:
+                print("\t\t{}".format(curr_target_value))
+
+    print("")
+
+    print("=========")
+    print("Variables")
+    print("=========")
+    for k,v in variables.items():
+        print("{} = {}".format(k,v))
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -19,6 +19,19 @@ def test_Makefile(makefile_name = "Makefile", makefile_path = ".") -> list:
     # Output processed data
     return [targets, variables]
 
+def test_export_Makefile(targets, variables, makefile_name="Makefile", makefile_path=".") -> None:
+    # Initialize Variables
+    makefile_parser = MakefileParser(makefile_name, makefile_path) # Initialize Makefile Parser
+
+    # Export Makefile dictionaries to Makefile
+    makefile_parser.export_Makefile(targets, variables, makefile_name, makefile_path)
+
+    # Process imported Makefile contents
+
+    # Use processed data
+
+    # Output processed data
+
 def main():
     """
     Unit Test launcher
@@ -66,6 +79,12 @@ def main():
     print("=========")
     for k,v in variables.items():
         print("{} = {}".format(k,v))
+
+    print("")
+
+    # Export Makefile
+    print("Testing Export Makefile...")
+    test_export_Makefile(targets, variables)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### 2024-03-24
#### 2204H
- Updates
    - Updated source file 'mkparser.py' in 'src/mkparser'
        + Added Makefile parser implementation (to be tested)

#### 2208H
- Updates
    - Updated document 'README.md'
        + Fixed pip install URL

#### 2344H
- New
    - Added new directory 'tests/' for writing unit tests and other tests
        + Added new unit test source 'unittest.py' for holding the main unit tests
        - Added new directory 'resources/' for holding test resource files
            - Added new directory 'Makefiles' for holding Makefile resources
                + Added new test Makefile 'test.Makefile'

- Updates
    - Updated document 'README.md'
        + Added new instruction for installing package in editable local development mode
    - Updated document 'requirements.txt'
        + Added the repository's github link as an installable pip package
    - Updated source file 'main.py' in 'src/'
    - Updated source file 'mkparse.py' in 'src/mkparse'
        + Swapped parameter/argument signatures
        + The variable dictionary now returns the operator (string), and the values (list) mapped to the variable name
        - Fixing implementation of Makefile Parser in 'parse_makefiles();'
            - Target is still bugged
                + Having issues detecting if dependencies is found

### 2024-03-25
#### 1202H
- Updates
    - Updated unit test file 'unittest.py' in 'tests/'
        + Modified to match test requirements
    - Updated source file 'mkparse.py' in 'src/mkparse'
        + Fixed Makefile to Python parser logic - To be tested
        + Wrote documentation comment headers in function
        - Added new function 'export_makefile' to export the target and variable dictionaries into a proper Makefile structure
            + To be tested with print statement first

#### 1335H
- Updates
    - Updated unit test file 'unittest.py' in 'tests/'
        + Modified to match test requirements
    - Updated source file 'mkparse.py' in 'src/mkparse'
        - Fixed function 'export_Makefile'
            + Able to export to a Makefile 
        - TODO
            + To implement reading of comments outside of variables and targets

#### 1430H
+ Version: v0.3.0

- Version Changes
    + Added working Makefile-to-Python import/parser support
    + Added working Python-to-Makefile export function

- TODO Ideas
    + Add comment import such that all comments on the global scope (not tied to any targets) will be retrievable

- Updates
    - Updated source file 'mkparse.py' in 'src/mkparse'
        - Function 'makefile_parse()'
            + Added logical check for comments ('#') and to map that line number to the comment for future use
            + Added 'comments' to the return list
            + Added 'comments' to the documentation multiline docstring
    - Updated document 'USAGE.md'
        + Fixed usage example of 'parse_makefile()': Swapped the argument signatures
        + Updated return list of 'parse_makefile()'
        + Added documentation for function 'export_makefile()'
        + Updated general usage examples
