### PR TITLE
v0.4.0

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -156,3 +156,25 @@
     - Updated unit test file 'unittest.py' in 'tests/'
         + Added error message output in the test for export_makefile
 
+#### 2217H
++ Version: v0.4.0
+
+- Version Changes
+    - mkparse
+        + Added new function 'format_makefile_Contents(...)': Function to format the imported targets and variables into printable string then appended into lists of the respective types
+
+- Updates
+    - Updated document 'README.md'
+        + Updated version number to 0.4.0
+    - Updated Python packaging script 'setup.py' for setuptools
+        + Updated version number to 0.4.0
+    - Updated source file 'mkparse.py' in 'src/mkparse'
+        + Added new function 'format_makefile_Contents': Function to format the imported targets and variables into printable string then appended into lists of the respective types
+    - Updated unit test file 'unittest.py' in 'tests/'
+        + Performed some cleanup
+        + Added unit test for 'format_makefile_Contents'
+        + Formatted unit tests
+    - Updated document 'USAGE.md'
+        + Added documentation for function 'format_makefile_Contents()'
+        + Added usage examples for the Makefile imported data-into-string formatting
+

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Makefile Parser in Python
 
 ### Project
 + Package Name: mkparser-python
-+ Current Version: v0.3.3
++ Current Version: v0.4.0
 
 ## Setup
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -108,7 +108,63 @@ Information regarding the various ways to use this Makefile parser
                     [target-name] : your dependencies here
                         # Instructions/statements
                     ```
-        """
+
+    - `def format_makefile_Contents(self, targets:dict, variables:dict) -> dict`: Format provided makefile targets and variables into content strings
+        - Parameter/Argument Signature
+            - targets: Specify the Makefile targets to format
+                + Type: Dictionary
+                - Format
+                    {
+                        "target-name" : {
+                            "dependencies" : [your, dependencies, here],
+                            "statements" : [your, statements, here]
+                        }
+                    }
+                - Key-Value Explanation
+                    - target-name : Each entry of 'target-name' contains a Makefile build target/instruction/rule 
+                        - Key-Value Mappings
+                            - dependencies : Specify a list of all dependencies 
+                                - Notes: 
+                                    - Dependencies are the pre-requisite rules to execute before executing the mapped target
+                                        - i.e.
+                                            [target-name]: [dependencies ...]
+                            - statements : Specify a list of all rows of statements to write under the target
+            - variables: Specify the Makefile variables to format
+                + Type: Dictionary
+                - Format
+                    {
+                        "variable-name" : {
+                            "operator" : "operator (i.e. =|?=|:=)",
+                            "value" : [your, values, here]
+                        }
+                    }
+                - Key-Value Explanation
+                    - variable-name : Each entry of 'variable-name' contains a Makefile variable/ingredient
+                        - Key-Value Mappings
+                            - operator : Specify the operator to map the variable to its value string/array/list
+                                + Type: String
+                                - Operator Keyword Types
+                                    + '='
+                                    + '?='
+                                    + ':='
+                            - value : Specify the value string/array/list (as a list) that you want to map to the variable
+                                + Type: List
+
+        - Return
+            - contents: Dictionary (key-value) Mapping of the formatted strings, stored in a list of the targets and variables respectively
+                + Type: Dictionary
+                - Key-Value mappings
+                    - targets : List of all targets formatted into a printable string
+                        + Type: List
+                    - variables : List of all variables formatted into a printable string
+                        + Type: List
+                + Format
+                    ```python
+                    contents = {
+                        "targets" : [],
+                        "variables" : []
+                    }
+                    ```
 
 ### Data Classes/Types
 
@@ -170,13 +226,39 @@ Information regarding the various ways to use this Makefile parser
     ```
 
 - Process imported Makefile contents
-    ```python
-    ```
+    - Format Makefile contents into string
+        ```python
+        # Format Makefile output into formatted string
+        formatted_makefile_Contents = makefile_parser.format_makefile_Contents(targets, variables)
+
+        # Process imported Makefile contents
+        formatted_makefile_Targets = formatted_makefile_Contents["targets"]
+        formatted_makefile_Variables = formatted_makefile_Contents["variables"]
+        ```
 
 - Use processed data
     ```python
-    print("Targets: {}".format(targets))
-    print("Variables: {}".format(variables))
+    print("=========")
+    print("Variables")
+    print("=========")
+    for i in range(len(formatted_makefile_Variables)):
+        # Get current line
+        curr_line = formatted_makefile_Variables[i]
+        # Print
+        print(curr_line)
+
+    print("")
+
+    print("=======")
+    print("Targets")
+    print("=======")
+    for i in range(len(formatted_makefile_Targets)):
+        # Get current line
+        curr_line = formatted_makefile_Targets[i]
+        # Print
+        print(curr_line)
+
+    print("")
     ```
 
 - Output processed data 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mkparse',
-    version='0.3.3',
+    version='0.4.0',
     description="A simple Makefile Parser written in Python that is designed to simplify the process of importing Makefile contents into python as dictionary (key-value mappings (i.e. hashmap/associative arrays)) objects",
     author='Thanatisia',
     author_email='55834101+Thanatisia@users.noreply.github.com',

--- a/src/mkparse/mkparse.py
+++ b/src/mkparse/mkparse.py
@@ -305,3 +305,83 @@ class MakefileParser():
 
         return error_msg
 
+    def format_makefile_Contents(self, targets:dict, variables:dict) -> dict:
+        """
+        Format provided makefile targets and variables into content strings
+
+        :: Params
+        - targets: Specify the Makefile targets to format
+            + Type: Dictionary
+            - Format
+                {
+                    "target-name" : {
+                        "dependencies" : [your, dependencies, here],
+                        "statements" : [your, statements, here]
+                    }
+                }
+            - Key-Value Explanation
+                - target-name : Each entry of 'target-name' contains a Makefile build target/instruction/rule 
+                    - Key-Value Mappings
+                        - dependencies : Specify a list of all dependencies 
+                            - Notes: 
+                                - Dependencies are the pre-requisite rules to execute before executing the mapped target
+                                    - i.e.
+                                        [target-name]: [dependencies ...]
+                        - statements : Specify a list of all rows of statements to write under the target
+        - variables: Specify the Makefile variables to format
+            + Type: Dictionary
+            - Format
+                {
+                    "variable-name" : {
+                        "operator" : "operator (i.e. =|?=|:=)",
+                        "value" : [your, values, here]
+                    }
+                }
+            - Key-Value Explanation
+                - variable-name : Each entry of 'variable-name' contains a Makefile variable/ingredient
+                    - Key-Value Mappings
+                        - operator : Specify the operator to map the variable to its value string/array/list
+                            + Type: String
+                            - Operator Keyword Types
+                                + '='
+                                + '?='
+                                + ':='
+                        - value : Specify the value string/array/list (as a list) that you want to map to the variable
+                            + Type: List
+
+        :: Output
+        - contents: Dictionary (key-value) Mapping of the formatted strings, stored in a list of the targets and variables respectively
+            + Type: Dictionary
+            - Key-Value mappings
+                - targets : List of all targets formatted into a printable string
+                    + Type: List
+                - variables : List of all variables formatted into a printable string
+                    + Type: List
+        """
+        # Initialize Variables
+        contents = {"targets" : [], "variables" : []}
+
+        for var_name, var_values in variables.items():
+            # Get variable operator
+            curr_var_operator = var_values["operator"]
+
+            # Get variable value
+            curr_var_value = ' '.join(var_values["value"])
+
+            # Format current variable
+            curr_out_string = "{} {} {}".format(var_name, curr_var_operator, curr_var_value)
+            contents["variables"].append(curr_out_string)
+
+        for target_name, target_settings in targets.items():
+            # Get current target dependencies
+            curr_target_dependencies = ' '.join(target_settings["dependencies"])
+
+            # Get current target statements
+            curr_target_statements = '\n'.join(target_settings["statements"])
+
+            # Format current variable
+            curr_out_string = "{}: {}\n{}\n".format(target_name, curr_target_dependencies, curr_target_statements)
+            contents["targets"].append(curr_out_string)
+
+        return contents
+

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -32,6 +32,22 @@ def test_export_Makefile(targets, variables, makefile_name="Makefile", makefile_
 
     # Output processed data
 
+def test_format_Makefile(targets, variables, makefile_name="Makefile", makefile_path=".") -> list:
+    # Initialize Variables
+    makefile_parser = MakefileParser(makefile_name, makefile_path) # Initialize Makefile Parser
+
+    # Format Makefile output into formatted string
+    formatted_makefile_Contents = makefile_parser.format_makefile_Contents(targets, variables)
+
+    # Process imported Makefile contents
+    formatted_makefile_Targets = formatted_makefile_Contents["targets"]
+    formatted_makefile_Variables = formatted_makefile_Contents["variables"]
+
+    # Use processed data
+
+    # Output processed data
+    return [formatted_makefile_Targets, formatted_makefile_Variables]
+
 def main():
     """
     Unit Test launcher
@@ -49,36 +65,33 @@ def main():
         makefile_name = argv[1]
 
     # Test Makefile import
+    print("Testing Makefile import...")
     targets, variables, comments = test_Makefile(makefile_name, makefile_path)
-    print("=======")
-    print("Targets")
-    print("=======")
-    for k,v in targets.items():
-        print("{} = {}".format(k,v))
-        """
-        print("{} = ".format(k))
-        for curr_target_key, curr_target_value in v.items():
-            print("RAW: {} = {}".format(curr_target_key, curr_target_value))
-            print("[{}]".format(curr_target_key))
-            # Perform type checks
-            if type(curr_target_value) == list:
-                # List type, print
-                print("\t\t{}".format(curr_target_value))
-                for i in range(len(curr_target_value)):
-                    # Get current value
-                    curr_val = curr_target_value[i]
-                    print("\t\t{}".format(curr_val))
-            else:
-                print("\t\t{}".format(curr_target_value))
-        """
 
     print("")
 
+    # Test Makefile data formatting
+    print("Testing Makefile data formatting...")
+    formatted_makefile_Targets, formatted_makefile_Variables = test_format_Makefile(targets, variables, makefile_name, makefile_path)
     print("=========")
     print("Variables")
     print("=========")
-    for k,v in variables.items():
-        print("{} = {}".format(k,v))
+    for i in range(len(formatted_makefile_Variables)):
+        # Get current line
+        curr_line = formatted_makefile_Variables[i]
+        # Print
+        print(curr_line)
+
+    print("")
+
+    print("=======")
+    print("Targets")
+    print("=======")
+    for i in range(len(formatted_makefile_Targets)):
+        # Get current line
+        curr_line = formatted_makefile_Targets[i]
+        # Print
+        print(curr_line)
 
     print("")
 


### PR DESCRIPTION
+ Version: v0.4.0

- Version Changes
    - mkparse
        + Added new function 'format_makefile_Contents(...)': Function to format the imported targets and variables into printable string then appended into lists of the respective types

- Updates
    - Updated document 'README.md'
        + Updated version number to 0.4.0
    - Updated Python packaging script 'setup.py' for setuptools
        + Updated version number to 0.4.0
    - Updated source file 'mkparse.py' in 'src/mkparse'
        + Added new function 'format_makefile_Contents': Function to format the imported targets and variables into printable string then appended into lists of the respective types
    - Updated unit test file 'unittest.py' in 'tests/'
        + Performed some cleanup
        + Added unit test for 'format_makefile_Contents'
        + Formatted unit tests
    - Updated document 'USAGE.md'
        + Added documentation for function 'format_makefile_Contents()'
        + Added usage examples for the Makefile imported data-into-string formatting
