### PR TITLE
fixed requirements.txt for installing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
 # Python package requirements/dependencies
-
 pyright
-git+https://github.com/Thanatisia/makefile-parser-python
-


### PR DESCRIPTION
fixed the following error:
```
ERROR: Cannot install mkparse 0.6.0 (from /home/xiaoji/文档/autopkg-make/makefile-parser-python) and mkparse 0.6.0 (from git+https://github.com/Thanatisia/makefile-parser-python) because these package versions have conflicting dependencies.
The conflict is caused by:
    The user requested mkparse 0.6.0 (from /home/xiaoji/文档/autopkg-make/makefile-parser-python)
    The user requested mkparse 0.6.0 (from git+https://github.com/Thanatisia/makefile-parser-python)
```